### PR TITLE
Use pyppeteer instead of pdfkit to render PDFs

### DIFF
--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -29,15 +29,15 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 USE_X_FORWARDED_HOST = True
 
-WKHTMLTOPDF_CMD_OPTIONS = {
-    'page-size': 'A4',
-    'margin-left': '0.75in',
-    'margin-right': '0.75in',
-    'margin-top': '0.62in',
-    'margin-bottom': '1in',
-    'print-media-type': '',
-    'no-stop-slow-scripts': '',
-    'javascript-delay': '30000',  # max wait until rendering finishes
+PYPPETEER_PDF_OPTIONS = {
+    'margin': {
+        'left': '0.75in',
+        'right': '0.75in',
+        'top': '0.62in',
+        'bottom': '1in',
+    },
+    'format': 'A4',
+    'printBackground': True,
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,5 @@ ipython
 pytz
 django-websocket-redis
 openpyxl
-pdfkit==0.6.1
-xvfbwrapper==0.2.9
+pyppeteer~=0.2.5
 raven

--- a/trans/static/css/pdf.css
+++ b/trans/static/css/pdf.css
@@ -1,7 +1,6 @@
 
 body {
     margin: 3em 5em;
-    zoom: .9;
     text-align: justify;
     background-color: rgb(82, 86, 89);
 }
@@ -84,7 +83,7 @@ div.pdf {
 
 .pdf.markdown-body {
     color: black;
-    font-size: 16px;
+    font-size: 14px;
 }
 
 .pdf.markdown-body code {
@@ -99,7 +98,6 @@ div.pdf {
 @media print {
 
     body {
-        zoom: 1.2;
         margin: 0;
         background-color: white;
     }


### PR DESCRIPTION
This has better support for rendering right-to-left scripts. Some scripts were also rendered incorrectly in pdfkit due to it using old version of webkit.