### PR TITLE
Don't capitalize first letter of task names

### DIFF
--- a/trans/templates/editor.html
+++ b/trans/templates/editor.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %} {{ task_name | capfirst}} {% endblock %}
+{% block title %} {{ task_name }} {% endblock %}
 
 {% block statics %}
 

--- a/trans/templates/home.html
+++ b/trans/templates/home.html
@@ -38,7 +38,7 @@
                 <tbody>
                 {% for task in contest.tasks %}
                     <tr>
-                        <td> {{ task.name | capfirst }} </td>
+                        <td> {{ task.name }} </td>
                         <td>
                             {% if task.is_editing %} Is editing
                             {% elif task.frozen %} Frozen

--- a/trans/templates/pdf-template.html
+++ b/trans/templates/pdf-template.html
@@ -4,7 +4,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{{ task_name | capfirst }} - {{contest}} - {{settings.CONTEST_TITLE}}</title>
+    <title>{{ task_name }} - {{contest}} - {{settings.CONTEST_TITLE}}</title>
     <link rel="shortcut icon" href="{{ static_path }}/img/favicon.png"/>
 
     <link rel="stylesheet" href="{{ static_path }}/libs/markdown/katex.css">

--- a/trans/templates/revisions.html
+++ b/trans/templates/revisions.html
@@ -3,7 +3,7 @@
 {% load list_filter %}
 {% load timezone_filter %}
 
-{% block title %} {{ task_name | capfirst}} : History {% endblock %}
+{% block title %} {{ task_name }} : History {% endblock %}
 
 {% block content %}
 
@@ -21,7 +21,7 @@
                     <table class="table table-version table-hover">
                         <thead><tr>
                             <td colspan="4">
-                                {{ task_name | capfirst }} 
+                                {{ task_name }} 
                                 {% if task_type == 'released'%} (ISC) {% endif %}
                             </td>
                         </tr></thead>

--- a/trans/templates/user.html
+++ b/trans/templates/user.html
@@ -54,7 +54,7 @@
             <tbody>
             {% for task in contest.tasks %}
             <tr>
-                <td> {{ task.name | capfirst }}</td>
+                <td> {{ task.name }}</td>
                 <td>
                     {% if task.is_editing %} Is editing
                     {% elif task.frozen %} Finalized

--- a/trans/utils/pdf.py
+++ b/trans/utils/pdf.py
@@ -115,7 +115,7 @@ def convert_html_to_pdf(html, pdf_file_path):
 def add_page_numbers_to_pdf(pdf_file_path, task_name):
     color =  '-color "0.4 0.4 0.4" '
     cmd = ('cpdf -add-text "{0} (%Page of %EndPage)   " -font "Arial" ' + color + \
-          '-font-size 10 -bottomright .62in {1} -o {1}').format(task_name.capitalize(), pdf_file_path)
+          '-font-size 10 -bottomright .62in {1} -o {1}').format(task_name, pdf_file_path)
     os.system(cmd)
 
 


### PR DESCRIPTION
Nowadays, IOI task names are using slug-style naming, e.g. `mushrooms`, `boxes`. It is weird to have it capitalized in the translation web panel and in the rendered PDFs.