### PR TITLE
fix `initial_data.json` syntax

### DIFF
--- a/initial_data.json
+++ b/initial_data.json
@@ -82,7 +82,7 @@
       "text_font_base64": "",
       "text_font_name": "",
       "is_onsite": true,
-      "is_translating": true,
+      "is_translating": true
     }
   },
   {
@@ -94,7 +94,7 @@
       "text_font_base64": "",
       "text_font_name": "",
       "is_onsite": true,
-      "is_translating": true,
+      "is_translating": true
     }
   },
   {
@@ -106,7 +106,7 @@
       "text_font_base64": "",
       "text_font_name": "",
       "is_onsite": true,
-      "is_translating": true,
+      "is_translating": true
     }
   },
   {


### PR DESCRIPTION
```
Trailing commas are not allowed in JSON, and consequently Python's `json` module refuses to parse it.

  $ python -c '__import__("json").load(open("initial_data.json"))'
  [...]
  json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 86 column 5 (char 1923)

Fixes: 254f5106d28587 ("Adjust initial_data.json to model changes")
```

This could just be squashed into 254f5106d28587bcde3664aa4cb36d77e5eda759.