### PR TITLE
docker-compose.yml: fix volume name typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,4 +57,4 @@ volumes:
   ioi_pgdata:
   ioi_static:
   ioi_media:
-  ioi_lots:
+  ioi_logs:


### PR DESCRIPTION
```
Fixes: 3522aa17df4a1e ("3522aa17df4a1eb2ea4e33de0df3e8c95653e23d")
```

Might be best to just squash this into 3522aa17df4a1eb2ea4e33de0df3e8c95653e23d.