### PR TITLE
docker-compose-dev.yml: fix exposed port on the `app` container

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
     restart: always
     build: ./
     ports:
-    - 9001:8000 # Debugging
+    - 9001:9000 # Debugging
     volumes:
     - .:/opt/translate/app/ # Debugging
     - ioi_static:/opt/translate/app/static/


### PR DESCRIPTION
As per docker-entrypoint.sh, gunicorn is accepting requests on port 9000, not 8000.