### PR TITLE
trans: allow more characters in task names

### DIFF
--- a/trans/templates/modals.html
+++ b/trans/templates/modals.html
@@ -81,8 +81,8 @@
                 alert('Task name is empty.')
                 return false;
             }
-            if (/[^a-z]/.test(name)) {
-                alert('Name can only contain lower-case letters.')
+            if (/[^a-zA-Z0-9_]/.test(name)) {
+                alert('Name can only contain lower-case and upper-case letters, decimal digits, and the `_` character.')
                 return false;
             }
             return true;


### PR DESCRIPTION
```
Currently, only lower case letters are allowed. However,
CMS allows [a-zA-Z0-9_-] characters in a tasks code name.
So extend the set of allowed characters, but note that the
hyphen is excluded because the task names appear in file
names that are passed in command line arguments and initial
hyphens might be misinterpreted as command line options.
```