### PR TITLE
PDF generation: use playwright instead of pyppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN python3 -m venv --system-site-packages /opt/translate/venv
 COPY requirements.txt constraints.txt /opt/translate/
 RUN /opt/translate/venv/bin/pip3 install -r /opt/translate/requirements.txt -c /opt/translate/constraints.txt
 
-RUN /opt/translate/venv/bin/python3 -c 'import pyppeteer.command; pyppeteer.command.install()'
+RUN /opt/translate/venv/bin/playwright install
 
 COPY trans/static/fonts/ /usr/local/share/fonts/
 

--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -204,7 +204,7 @@ CACHE_DIR = os.path.join(BASE_DIR, "cache")
 
 # Settings related to production of PDFs from the Markdown sourcs
 
-PYPPETEER_PDF_OPTIONS = {
+PLAYWRIGHT_PDF_OPTIONS = {
     'margin': {
         'left': '0.75in',
         'right': '0.75in',
@@ -212,7 +212,7 @@ PYPPETEER_PDF_OPTIONS = {
         'bottom': '1in',
     },
     'format': 'A4',
-    'printBackground': True,
+    'print_background': True,
 }
 
 # This is standard A4

--- a/constraints.txt
+++ b/constraints.txt
@@ -57,7 +57,6 @@ pyasn1_modules==0.4.0
 pycairo==1.20.1
 pyee==11.1.0
 Pygments==2.18.0
-pyppeteer==2.0.0
 python-dateutil==2.9.0.post0
 python-markdown-math==0.8
 pytz==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ ipython
 moratab
 openpyxl
 pikepdf
+playwright
 psycopg2
 pycairo
-pyppeteer
 python-markdown-math
 pytz
 raven

--- a/trans/utils/pdf.py
+++ b/trans/utils/pdf.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 
-from pyppeteer import launch
+from playwright.sync_api import sync_playwright, Playwright
 
 from trans.context_processors import ioi_settings
 from trans.models import Translation, User
@@ -57,7 +57,7 @@ def build_pdf(translation: Translation, task_type: str) -> str:
     with TemporaryDirectory(dir=_temp_dir_path()) as temp_dir:
         temp_dir_path = Path(temp_dir)
         loop = asyncio.get_event_loop()
-        browser_pdf_path = loop.run_until_complete(_convert_html_to_pdf(html, temp_dir_path))
+        browser_pdf_path = _convert_html_to_pdf(html, temp_dir_path)
         transformed_pdf_path = temp_dir_path / 'transformed.pdf'
         if settings.USE_CPDF:
             _add_page_numbers_to_pdf(browser_pdf_path, transformed_pdf_path, task.name)
@@ -146,21 +146,20 @@ def _temp_dir_path() -> Path:
     return temp_path
 
 
-async def _convert_html_to_pdf(html: str, temp_dir_path: Path) -> Path:
+def _convert_html_to_pdf(html: str, temp_dir_path: Path) -> Path:
     html_file = temp_dir_path / 'source.html'
     pdf_file = temp_dir_path / 'browser.pdf'
 
     try:
         with open(html_file, 'w') as f:
             f.write(html)
-        browser = await launch(options={'args': ['--no-sandbox']})
-        page = await browser.newPage()
-        await page.goto('file://{}'.format(html_file), {
-            'waitUntil': 'networkidle2',
-        })
-        await page.emulateMedia('print')
-        await page.pdf({'path': str(pdf_file), **settings.PYPPETEER_PDF_OPTIONS})
-        await browser.close()
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            page = browser.new_page()
+            page.goto('file://{}'.format(html_file), wait_until = "networkidle")
+            # page.emulateMedia('print')
+            page.pdf(path = str(pdf_file), **settings.PLAYWRIGHT_PDF_OPTIONS)
+            browser.close()
     except Exception as e:
         logger.error(e)
 


### PR DESCRIPTION
`pyppeteer`, by default, uses a pretty outdated version of chromium (117.0.5938.0).

That version does not handle tables over page breaks very well, in some cases causing tables that don't fit at the bottom of a page to be spread across multiple pages, with those pages being otherwise empty.
The resulting statements could be extremely confusing to contestants.

By swapping out `pyppeteer` for `playwright`, we can use a more recent version of chromium, which handles tables much better (in the aforementioned case, the entire table will be placed after the page break, intact).